### PR TITLE
PHP 8.1 compatibility

### DIFF
--- a/WMDE/Fundraising/ruleset.xml
+++ b/WMDE/Fundraising/ruleset.xml
@@ -20,9 +20,18 @@
 		<exclude name="MediaWiki.Commenting.PropertyDocumentation.MissingDocumentationPrivate" />
 		<exclude name="MediaWiki.Commenting.PropertyDocumentation.MissingDocumentationProtected" />
 
-		<!-- Allow assert - we use it for some domain-specific sanity checks where the type system would -->
-		<!-- TODO: Add sniff to make sure assert is only called with boolean expressions -->
-		<exclude name="MediaWiki.Usage.ForbiddenFunctions.assert" />
+        <!--
+            The following sniffs are interfering with PHP 8.1 intersection types using "&"
+            Remove the exclusions when they are ready for PHP 8.1
+            See https://github.com/squizlabs/PHP_CodeSniffer/issues/3479
+            See https://phabricator.wikimedia.org/T305140
+        -->
+        <exclude name="Squiz.Functions.FunctionDeclarationArgumentSpacing.SpacingAfterReference" />
+        <exclude name="MediaWiki.Commenting.FunctionComment.ParamPassByReference" />
+
+        <!-- Allow assert - we use it for some domain-specific sanity checks where the type system would -->
+        <!-- TODO: Add sniff to make sure assert is only called with boolean expressions -->
+        <exclude name="MediaWiki.Usage.ForbiddenFunctions.assert" />
     </rule>
 
     <rule ref="Generic.Files.LineLength">

--- a/WMDE/Fundraising/ruleset.xml
+++ b/WMDE/Fundraising/ruleset.xml
@@ -4,7 +4,10 @@
         <!-- we'll define our own line length rule that ignores long test names -->
         <exclude name="Generic.Files.LineLength" />
 
-        <!-- Docblocks should be completely optional, type annotations are better -->
+        <!-- Docblocks should be completely optional, type annotations are better 
+            See https://phabricator.wikimedia.org/T258925
+            See https://phabricator.wikimedia.org/T288754
+        -->
         <exclude name="MediaWiki.Commenting.FunctionComment.MissingDocumentationPrivate" />
         <exclude name="MediaWiki.Commenting.FunctionComment.MissingDocumentationProtected" />
         <exclude name="MediaWiki.Commenting.FunctionComment.MissingDocumentationPublic" />
@@ -16,9 +19,9 @@
         <!-- Allow indentation in Docblock annotations for setting Doctrine indexes -->
         <exclude name="MediaWiki.Commenting.DocComment.SpacingDocTag" />
 
-		<!-- Don't force docblocks for scope annotation, we use PHP keywords for that -->
-		<exclude name="MediaWiki.Commenting.PropertyDocumentation.MissingDocumentationPrivate" />
-		<exclude name="MediaWiki.Commenting.PropertyDocumentation.MissingDocumentationProtected" />
+        <!-- Don't force docblocks for scope annotation, we use PHP keywords for that -->
+        <exclude name="MediaWiki.Commenting.PropertyDocumentation.MissingDocumentationPrivate" />
+        <exclude name="MediaWiki.Commenting.PropertyDocumentation.MissingDocumentationProtected" />
 
         <!--
             The following sniffs are interfering with PHP 8.1 intersection types using "&"

--- a/WMDE/Fundraising/ruleset.xml
+++ b/WMDE/Fundraising/ruleset.xml
@@ -31,10 +31,6 @@
         -->
         <exclude name="Squiz.Functions.FunctionDeclarationArgumentSpacing.SpacingAfterReference" />
         <exclude name="MediaWiki.Commenting.FunctionComment.ParamPassByReference" />
-
-        <!-- Allow assert - we use it for some domain-specific sanity checks where the type system would -->
-        <!-- TODO: Add sniff to make sure assert is only called with boolean expressions -->
-        <exclude name="MediaWiki.Usage.ForbiddenFunctions.assert" />
     </rule>
 
     <rule ref="Generic.Files.LineLength">


### PR DESCRIPTION
Add workaround for false positives on PHP 8.1 intersection types being
interpreted as pass-by-reference

See https://phabricator.wikimedia.org/T305140