### PR TITLE
Remove unneeded rules

### DIFF
--- a/WMDE/Fundraising/ruleset.xml
+++ b/WMDE/Fundraising/ruleset.xml
@@ -4,33 +4,12 @@
         <!-- we'll define our own line length rule that ignores long test names -->
         <exclude name="Generic.Files.LineLength" />
 
-        <!-- Docblocks should be completely optional, type annotations are better 
-            See https://phabricator.wikimedia.org/T258925
-            See https://phabricator.wikimedia.org/T288754
-        -->
-        <exclude name="MediaWiki.Commenting.FunctionComment.MissingDocumentationPrivate" />
-        <exclude name="MediaWiki.Commenting.FunctionComment.MissingDocumentationProtected" />
-        <exclude name="MediaWiki.Commenting.FunctionComment.MissingDocumentationPublic" />
-
         <!-- Ignore unknown annotations -->
         <!-- TODO: Define our own set of allowed annotations -->
         <exclude name="MediaWiki.Commenting.FunctionAnnotations.UnrecognizedAnnotation" />
 
         <!-- Allow indentation in Docblock annotations for setting Doctrine indexes -->
         <exclude name="MediaWiki.Commenting.DocComment.SpacingDocTag" />
-
-        <!-- Don't force docblocks for scope annotation, we use PHP keywords for that -->
-        <exclude name="MediaWiki.Commenting.PropertyDocumentation.MissingDocumentationPrivate" />
-        <exclude name="MediaWiki.Commenting.PropertyDocumentation.MissingDocumentationProtected" />
-
-        <!--
-            The following sniffs are interfering with PHP 8.1 intersection types using "&"
-            Remove the exclusions when they are ready for PHP 8.1
-            See https://github.com/squizlabs/PHP_CodeSniffer/issues/3479
-            See https://phabricator.wikimedia.org/T305140
-        -->
-        <exclude name="Squiz.Functions.FunctionDeclarationArgumentSpacing.SpacingAfterReference" />
-        <exclude name="MediaWiki.Commenting.FunctionComment.ParamPassByReference" />
     </rule>
 
     <rule ref="Generic.Files.LineLength">


### PR DESCRIPTION
Bugfixes in the underlying MediaWiki rule set have made the rules obsolete.

We'll get a *lot* of errors for missing types that slipped through with our previous rules, but I think the consistency is worth it.